### PR TITLE
chore(deps): add dependabot to update dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: chore
+    prefix-development: chore
+    include: scope
+  open-pull-requests-limit: 13
+  target-branch: main
+  # Add additional reviewers for PRs opened by Dependabot. For more information, see:
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers
+  # reviewers:
+  # -
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: chore
+    prefix-development: chore
+    include: scope
+  open-pull-requests-limit: 13
+  target-branch: main
+  # Add additional reviewers for PRs opened by Dependabot. For more information, see:
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers
+  # reviewers:
+  # -


### PR DESCRIPTION
This PR adds Dependabot to automatically update project dependencies. It configures a Dependabot configuration file to monitor and manage updates for `maven` and `github-actions`.